### PR TITLE
Remove link line

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ All your sites get saved as .json files. You can set the directory they get save
 ## Running 
 
 1. `npm install`
-1. `npm link` from '@primo-af/primo' directory 
 1. `npm run start`
 
 ## Building 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,22 @@ Run primo on your Desktop
 
 All your sites get saved as .json files. You can set the directory they get saved to from within the app. 
 
-## Running 
+## Running
 
 1. `npm install`
 1. `npm run start`
+
+### Linking 
+
+Running this repo locally will let you modify the electron wrapper around Primo, but not the editor itself. To do that, you'll need to: 
+1. Clone [primo](https://github.com/primo-af/primo)
+1. `cd primo` 
+1. `npm install`
+1. `npm link`
+1. From `primo-desktop`, run `npm link @primo-app/primo` 
+1. `npm run start`
+
+This will make it so changes in either directory will be registered by vite. 
 
 ## Building 
 


### PR DESCRIPTION
Following this set seems impossible after `npm install` and does not match with the dev command from package.json `npm link @primo-app/primo` ... not sure this is correct.

```
primo-desktop/node_modules/@primo-app/primo % npm link
npm WARN tarball tarball data for @primo-app/primo@file:primo (null) seems to be corrupted. Trying again.
npm WARN tarball tarball data for @primo-app/primo@file:primo (null) seems to be corrupted. Trying again.
npm ERR! code ENOENT
npm ERR! syscall open
npm ERR! path /usr/local/lib/node_modules/@primo-app/primo/primo/package.json
npm ERR! errno -2
npm ERR! enoent ENOENT: no such file or directory, open '/usr/local/lib/node_modules/@primo-app/primo/primo/package.json'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent 

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/clemens/.npm/_logs/2021-11-28T14_14_25_693Z-debug.log
```